### PR TITLE
Fix incorrect timing of chime

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -20,7 +20,8 @@ import {
   DrawerOverlay,
   Link,
   Stack,
-  Text
+  Text,
+  useToast
 } from '@chakra-ui/react';
 import { useSound } from 'providers/SoundProvider';
 
@@ -45,6 +46,7 @@ const userLinks = [
 export const NavBar = () => {
   const history = useHistory();
   const { isOpen, onToggle, onClose } = useDisclosure();
+  const toast = useToast();
   const { user, logout } = useAuth();
   const { active, toggle, sounds } = useSound();
 
@@ -56,6 +58,13 @@ export const NavBar = () => {
   const handleBellClick = () => {
     if (!active) {
       sounds.bell.play();
+      toast({
+        title: "Not recommended with music",
+        description: "Sounds from the app may pause audio",
+        status: "warning",
+        duration: 9000,
+        isClosable: true,
+      })
     }
 
     toggle();

--- a/client/src/features/timer/components/Timer.tsx
+++ b/client/src/features/timer/components/Timer.tsx
@@ -107,8 +107,8 @@ export const Timer = ({ displayTimer }: TimerProps = defaultProps) => {
         setZoneSeconds(seconds => seconds - 1)
       }
       if (zoneSeconds === 0) {
-        if (soundActive) bell.play();
         if (zoneMinutes === 0 && zoneInterval < intervals.length - 1) {
+          if (soundActive) bell.play();
           const nextInterval = zoneInterval + 1
           setZoneInterval(nextInterval)
           const tempSeconds = Math.floor(intervals[nextInterval].length % 60);


### PR DESCRIPTION
## Problem
- Chime was ringing every minute
- Chime would pause music being played

## Solution
The chime was fixed so ring only when both zone minute and seconds are 0, rather than just seconds.

There's nothing that can be done about pausing music - it's system level. Fix was to implement a toast to recommend user not use phone for both music and timer.