### PR TITLE
Fix bug where refresh loses user context

### DIFF
--- a/backend/test/auth.js
+++ b/backend/test/auth.js
@@ -106,6 +106,15 @@ describe('Authentication', () => {
         })
 
       expect(validateResponse.status).to.eql(200);
+      expect(validateResponse.body).to.have.keys('jwt', 'user');
+      expect(validateResponse.body.jwt).to.be.a('string')
+      expect(validateResponse.body.user).to.have.keys(
+        'id',
+        'username',
+        'email',
+        'iat',
+        'exp'
+      );
     })
 
     it('should deny user with invalid token', async () => {

--- a/client/src/features/auth/api/validate.ts
+++ b/client/src/features/auth/api/validate.ts
@@ -1,9 +1,9 @@
 import { useQuery } from 'react-query';
 import { axios } from 'lib/axios';
 import { QueryConfig } from 'lib/react-query';
-import { AuthUser } from '../types';
+import { UserResponse } from '../types';
 
-export const validateUser = (): Promise<AuthUser> => {
+export const validateUser = (): Promise<UserResponse> => {
   return axios.get('/auth/validate');
 }
 

--- a/client/src/lib/auth.tsx
+++ b/client/src/lib/auth.tsx
@@ -18,8 +18,8 @@ const handleUserResponse = async (data: UserResponse) => {
 
 const loadUser = async () => {
   if (storage.getToken()) {
-    const data = await AuthAPI.validateUser();
-    return data;
+    const { user } = await AuthAPI.validateUser();
+    return user;
   }
   return null;
 }


### PR DESCRIPTION
## Problem
Page refresh was causing application to lose user context

## Solution
The `GET /auth/validate` route returns a data shape not expected by the frontend. The data expected is actually under the `user` property. 
- Axios request type is modified
- User is parsed from response
- Insufficient test is modified